### PR TITLE
API 3187 updates to the Python API client

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
  * Replaced: urllib2 with requests package
  * Replaced: oauth2 with requests_oauthlib package
  * Added: optional timeout parameter
+ * Removed: support for Python 2.4/2.5
 
 0.4.0 / 2013-07-23
 ==================

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A small class to help connect to the OpenX Enterprise API. As of version 0.5.0 it  uses
 [requests_oauthlib](https://github.com/requests/requests-oauthlib) instead of oauth2.
 
-It currently supports Python 2.4 - 2.7, with 3.x support coming in the future.
+It currently supports Python 2.6 - 2.7, with 3.x support coming in the future.
 
 As of version 0.4.0, ox3apiclient supports API v2. If your instance is v2,
 set the api_path option to "/ox/4.0".
@@ -33,7 +33,7 @@ order = {
     'status': 'Active',
     'name': 'OX3APIClient Object Creation Test',
     'account_uid': accounts['objects'][0]['account_uid'],
-    'start_date': '2015-06-01 00:00:00'}
+    'start_date': '2016-06-01 00:00:00'}
 
 new_order = ox.post('/order', data=order)
 
@@ -50,17 +50,12 @@ ox3apiclient is currently unavailable at [PyPi](http://pypi.python.org/pypi) so 
 ````
 $ git clone https://github.com/openx/OX3-Python-API-Client.git
 ````
-Install requests and requests_oauthlib from [PyPi](http://pypi.python.org/pypi) with [pip](http://www.pip-installer.org/en/latest/index.html)
-````
-$ pip install requests requests_oauthlib
-````
 
-Note that Python 2.4 and 2.5 support requires simplejson. You will need
-simplejson 2.1.0 specifically for Python 2.4. You can install this version with:
+Install the downloaded library:
 ````
-$ pip install simplejson==2.1.0
+python setup.py install
 ````
-
+this will install the current dependencies.
 
 ## Authentication
 

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,34 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 from os.path import dirname, join
 import re
 
 file_path = join(dirname(__file__), 'ox3apiclient', '__init__.py')
 version = re.search("__version__\s*=\s*['\"](.+)['\"]",
-    open(file_path, 'r').read()).groups()[0]
+                    open(file_path, 'r').read()).groups()[0]
 
 setup(name='ox3apiclient',
-    version=version,
-    author='Tony Edwards',
-    author_email='tnydwrds@gmail.com',
-    url='https://github.com/tnydwrds/OX3-Python-API-Client',
-    description='Client to connect to OpenX Enterprise API.',
-    long_description='Client to connect to OpenX Enterprise API.',
-    packages=['ox3apiclient'],
-    install_requires=['oauth2'],
-    classifiers=[
-        'Environment :: Console',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.4',
-        'Programming Language :: Python :: 2.5',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
-        'Topic :: Software Development :: Libraries',
-        'Topic :: Software Development :: Libraries :: Python Modules'])
+      version=version,
+      author='OpenX API Team',
+      author_email='api@openx.com',
+      url='https://github.com/openx/OX3-Python-API-Client',
+      description='Client to connect to OpenX Enterprise API.',
+      long_description='Client to connect to OpenX Enterprise API.',
+      packages=['ox3apiclient'],
+      install_requires=['requests_oauthlib'],
+      classifiers=[
+          'Environment :: Console',
+          'Environment :: Web Environment',
+          'Intended Audience :: Developers',
+          'Operating System :: OS Independent',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 2.6',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: Implementation :: CPython',
+          'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+          'Topic :: Software Development :: Libraries',
+          'Topic :: Software Development :: Libraries :: Python Modules'])


### PR DESCRIPTION
 - Dropped support for Python 2.4 and 2.5.
 - Simplified code dealing with python versions.
 - General formatting.
 - Setup:
	- Removed the 'oauth2' dependency.
 	- No intervention from user is needed to install requests_oauthlib.
	- Updated contact info.