### PR TITLE
Added python 3 support and cleaned up some testing files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .ox3rc
 *.pyc
+ox3apiclient.egg-info/
+landing/*
+build/*
+dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
 .ox3rc
 *.pyc
-ox3apiclient.egg-info/
-landing/*
-build/*
-dist/*

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A small class to help connect to the OpenX Enterprise API. As of version 0.5.0 it  uses
 [requests_oauthlib](https://github.com/requests/requests-oauthlib) instead of oauth2.
 
-It currently supports Python 2.6 - 2.7, with 3.x support coming in the future.
+It currently supports Python 2.6 - 3.5.
 
 As of version 0.4.0, ox3apiclient supports API v2. If your instance is v2,
 set the api_path option to "/ox/4.0".

--- a/ox3apiclient/__init__.py
+++ b/ox3apiclient/__init__.py
@@ -200,7 +200,7 @@ class Client(object):
         self._email = self._password = None
         # set token verifier
         self._token['verifier'] = parse_qs(response.text)['oauth_verifier'][0]
-          
+
     def fetch_access_token(self):
         """Helper method to fetch and set access token.
 
@@ -489,4 +489,3 @@ def client_from_file(file_path='.ox3rc', env=None):
 # The exposed API has moved to using Client instead of OX3APIClient, but create
 # a temporary alias for backwards compatibility.
 OX3APIClient = Client
-

--- a/ox3apiclient/__init__.py
+++ b/ox3apiclient/__init__.py
@@ -1,16 +1,17 @@
 # -*- coding: utf-8 -*-
-
-import ConfigParser
-import cookielib
+import six
+from six.moves import configparser as ConfigParser
+from six.moves import http_cookiejar as cookielib
 import logging
 import mimetypes
 from pprint import pformat
 import random
 import json
-from urlparse import parse_qs, urlparse
+from six.moves.urllib.parse import parse_qs, urlparse
 
 import requests
 from requests_oauthlib import OAuth1
+
 
 __version__ = '0.5.0'
 
@@ -123,9 +124,9 @@ class Client(object):
             self.logger.debug("%s: %s" % (k, v))
         self.logger.debug('====={0:=<45}'.format('OX3 api call response body'))
         try:
-            self.logger.debug(pformat(json.loads(response.content)))
+            self.logger.debug(pformat(json.loads(response.text)))
         except ValueError:
-            self.logger.debug("%s" % response.content)
+            self.logger.debug("%s" % response.text)
         self.logger.debug('====={0:=<45}'.format('OX3 api call finished'))
 
     def request(self, url, method='GET', headers=None, data=None, sign=False,
@@ -164,8 +165,8 @@ class Client(object):
         response = self._session.post(url=self.request_token_url, auth=oauth, timeout=self.timeout)
         self.log_request(response)
         if response.status_code != 200:
-            raise OAuthException("OAuth token request failed (%s) %s" % (response.status_code, response.content))
-        credentials = parse_qs(response.content)
+            raise OAuthException("OAuth token request failed (%s) %s" % (response.status_code, response.text))
+        credentials = parse_qs(response.text)
         self._token = {'key': credentials['oauth_token'][0],
                        'secret': credentials['oauth_token_secret'][0]}
         return self._token
@@ -193,13 +194,13 @@ class Client(object):
         response = self._session.post(url=self.authorization_url, data=data, timeout=self.timeout)
         self.log_request(response)
         if response.status_code != 200:
-            raise OAuthException("OAuth login failed (%s) %s" % (response.status_code, response.content))
+            raise OAuthException("OAuth login failed (%s) %s" % (response.status_code, response.text))
 
         # Clear user credentials.
         self._email = self._password = None
         # set token verifier
-        self._token['verifier'] = parse_qs(response.content)['oauth_verifier'][0]
-
+        self._token['verifier'] = parse_qs(response.text)['oauth_verifier'][0]
+          
     def fetch_access_token(self):
         """Helper method to fetch and set access token.
 
@@ -215,8 +216,9 @@ class Client(object):
         response = self._session.post(url=self.access_token_url, auth=oauth, timeout=self.timeout)
         self.log_request(response)
         if response.status_code != 200:
-            raise OAuthException("OAuth token verification failed (%s) %s" % (response.status_code, response.content))
-        self._token = parse_qs(response.content)['oauth_token'][0]
+            raise OAuthException("OAuth token verification failed (%s) %s" % (response.status_code, response.text))
+        self._token = parse_qs(response.text)['oauth_token'][0]
+
         return self._token
 
     def validate_session(self):
@@ -247,7 +249,7 @@ class Client(object):
         if self.api_path == API_PATH_V1:
             response = self._session.put(url=self._resolve_url('/a/session/validate'), timeout=self.timeout)
             self.log_request(response)
-            return response.content
+            return response.text
 
     def logon(self, email=None, password=None):
         """Returns self after authentication.
@@ -279,7 +281,7 @@ class Client(object):
 
             response = self._session.delete(url=self.access_token_url, auth=oauth, timeout=self.timeout)
             if response.status_code != 204:
-                raise OAuthException("OAuth token deletion failed (%s) %s" % (response.status_code, response.content))
+                raise OAuthException("OAuth token deletion failed (%s) %s" % (response.status_code, response.text))
         else:
             raise UnknownAPIFormatError(
                 'Unrecognized API path: %s' % self.api_path)
@@ -307,14 +309,14 @@ class Client(object):
         return url
 
     def _response_value(self, response):
-        """ Utility method. Returns decoded json. If the response content cannot be decoded, then
+        """ Utility method. Returns decoded json. If the response.text cannot be decoded, then
         the content is returned.
 
         """
         try:
             return response.json()
         except ValueError:
-            return response.content
+            return response.text
 
     def get(self, url):
         """Issue a GET request to the given URL or API shorthand
@@ -395,7 +397,9 @@ class Client(object):
         parts.append('Content-Type: %s' % mimetypes.guess_type(file_path)[0] or 'application/octet-stream')
         parts.append('')
         # TODO: catch errors with opening file.
-        parts.append(open(file_path, 'r').read())
+        # do this within a context manager to avoid unclosed file
+        with open(file_path, 'r') as f:
+          parts.append(f.read())
 
         parts.append('--' + boundary + '--')
         parts.append('')
@@ -485,3 +489,4 @@ def client_from_file(file_path='.ox3rc', env=None):
 # The exposed API has moved to using Client instead of OX3APIClient, but create
 # a temporary alias for backwards compatibility.
 OX3APIClient = Client
+

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='ox3apiclient',
       description='Client to connect to OpenX Enterprise API.',
       long_description='Client to connect to OpenX Enterprise API.',
       packages=['ox3apiclient'],
-      install_requires=['requests_oauthlib'],
+      install_requires=['requests_oauthlib', 'six'],
       classifiers=[
           'Environment :: Console',
           'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(name='ox3apiclient',
           'Programming Language :: Python',
           'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3'
           'Programming Language :: Python :: Implementation :: CPython',
           'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
           'Topic :: Software Development :: Libraries',

--- a/tests/client.py
+++ b/tests/client.py
@@ -4,7 +4,6 @@ import unittest
 from mock import Mock, patch
 import os
 
-
 class TestClient(unittest.TestCase):
     ex_resp = Mock()
     ex_resp.request.headers = {'rheader1': 'rvalue1',
@@ -32,27 +31,25 @@ class TestClient(unittest.TestCase):
         self.api_path_v2 = '/ox/4.0'
         self.url = 'https://www.example.com'
 
-        with patch('ox3apiclient.requests.Session') as\
-        self.mock_requests_session,\
-        patch('ox3apiclient.Client.log_request') as\
-        self.mock_client_log_request:
-          self.mock_requests_session.return_value.get.return_value = self.ex_resp
-          self.mock_requests_session.return_value.post.return_value = self.ex_resp
-          self.mock_requests_session.return_value.put.return_value = self.ex_resp
-          self.mock_requests_session.return_value.options.return_value = self.ex_resp
-          self.mock_requests_session.return_value.delete.return_value = self.ex_resp
+        with patch('ox3apiclient.requests.Session') as self.mock_requests_session:
+            with patch('ox3apiclient.Client.log_request') as self.mock_client_log_request:
+                self.mock_requests_session.return_value.get.return_value = self.ex_resp
+                self.mock_requests_session.return_value.post.return_value = self.ex_resp
+                self.mock_requests_session.return_value.put.return_value = self.ex_resp
+                self.mock_requests_session.return_value.options.return_value = self.ex_resp
+                self.mock_requests_session.return_value.delete.return_value = self.ex_resp
 
-          self.mock_client_log_request.return_value = None
-          self.client = ox3apiclient.Client(
-              email=self.email,
-              password=self.password,
-              domain=self.domain,
-              realm=self.realm,
-              consumer_key=self.consumer_key,
-              consumer_secret=self.consumer_secret,
-              request_token_url=self.request_token_url,
-              access_token_url=self.access_token_url,
-              authorization_url=self.authorization_url)
+                self.mock_client_log_request.return_value = None
+                self.client = ox3apiclient.Client(
+                      email=self.email,
+                      password=self.password,
+                      domain=self.domain,
+                      realm=self.realm,
+                      consumer_key=self.consumer_key,
+                      consumer_secret=self.consumer_secret,
+                      request_token_url=self.request_token_url,
+                      access_token_url=self.access_token_url,
+                      authorization_url=self.authorization_url)
 
     def test_init(self):
         pass
@@ -126,18 +123,16 @@ class TestClient(unittest.TestCase):
                          'oauth_callback_confirmed=true')
 
     def test_logon(self):
-        with patch('ox3apiclient.Client.fetch_request_token') as\
-        mock_fetch_request_token,\
-        patch('ox3apiclient.Client.authorize_token') as mock_authorize_token,\
-        patch('ox3apiclient.Client.fetch_access_token') as\
-        mock_fetch_access_token,\
-        patch('ox3apiclient.Client.validate_session') as mock_validate_session:
-            mock_fetch_request_token.return_value = None
-            mock_authorize_token.return_value = None
-            mock_fetch_access_token.return_value = None
-            mock_validate_session.return_value = None
-            ret_val = self.client.logon()
-            self.assertTrue(isinstance(ret_val, ox3apiclient.Client))
+        with patch('ox3apiclient.Client.fetch_request_token') as mock_fetch_request_token:
+            with patch('ox3apiclient.Client.authorize_token') as mock_authorize_token:
+                with patch('ox3apiclient.Client.fetch_access_token') as mock_fetch_access_token:
+                    with patch('ox3apiclient.Client.validate_session') as mock_validate_session:
+                        mock_fetch_request_token.return_value = None
+                        mock_authorize_token.return_value = None
+                        mock_fetch_access_token.return_value = None
+                        mock_validate_session.return_value = None
+                        ret_val = self.client.logon()
+                        self.assertTrue(isinstance(ret_val, ox3apiclient.Client))
 
     def test_logoff(self):
         ret_val = self.client.logoff()

--- a/tests/client.py
+++ b/tests/client.py
@@ -3,7 +3,6 @@ import ox3apiclient
 import unittest
 from mock import Mock, patch
 import os
-from contextlib import nested
 
 
 class TestClient(unittest.TestCase):
@@ -12,7 +11,7 @@ class TestClient(unittest.TestCase):
                                'rheader2': 'rvalue2'}
     ex_resp.headers = {'header1': 'value1',
                        'header2': 'value2'}
-    ex_resp.content = 'oauth_token=key&oauth_token_secret=secret&oauth_callback_confirmed=true'
+    ex_resp.text = 'oauth_token=key&oauth_token_secret=secret&oauth_callback_confirmed=true'
     ex_resp.json.return_value = {'key1': 'value1',
                                  'key2': 'value2',
                                  'key3': 'value3'}
@@ -33,28 +32,27 @@ class TestClient(unittest.TestCase):
         self.api_path_v2 = '/ox/4.0'
         self.url = 'https://www.example.com'
 
-        with nested(
-            patch('ox3apiclient.requests.Session'),
-            patch('ox3apiclient.Client.log_request')
-        ) as (self.mock_requests_session, self.mock_client_log_request):
+        with patch('ox3apiclient.requests.Session') as\
+        self.mock_requests_session,\
+        patch('ox3apiclient.Client.log_request') as\
+        self.mock_client_log_request:
+          self.mock_requests_session.return_value.get.return_value = self.ex_resp
+          self.mock_requests_session.return_value.post.return_value = self.ex_resp
+          self.mock_requests_session.return_value.put.return_value = self.ex_resp
+          self.mock_requests_session.return_value.options.return_value = self.ex_resp
+          self.mock_requests_session.return_value.delete.return_value = self.ex_resp
 
-            self.mock_requests_session.return_value.get.return_value = self.ex_resp
-            self.mock_requests_session.return_value.post.return_value = self.ex_resp
-            self.mock_requests_session.return_value.put.return_value = self.ex_resp
-            self.mock_requests_session.return_value.options.return_value = self.ex_resp
-            self.mock_requests_session.return_value.delete.return_value = self.ex_resp
-
-            self.mock_client_log_request.return_value = None
-            self.client = ox3apiclient.Client(
-                email=self.email,
-                password=self.password,
-                domain=self.domain,
-                realm=self.realm,
-                consumer_key=self.consumer_key,
-                consumer_secret=self.consumer_secret,
-                request_token_url=self.request_token_url,
-                access_token_url=self.access_token_url,
-                authorization_url=self.authorization_url)
+          self.mock_client_log_request.return_value = None
+          self.client = ox3apiclient.Client(
+              email=self.email,
+              password=self.password,
+              domain=self.domain,
+              realm=self.realm,
+              consumer_key=self.consumer_key,
+              consumer_secret=self.consumer_secret,
+              request_token_url=self.request_token_url,
+              access_token_url=self.access_token_url,
+              authorization_url=self.authorization_url)
 
     def test_init(self):
         pass
@@ -83,7 +81,7 @@ class TestClient(unittest.TestCase):
                              mock_fetch_request_token):
         # mock the post response, and do some setup
         r = Mock()
-        r.content = 'oauth_verifier=verifier'
+        r.text = 'oauth_verifier=verifier'
         self.mock_requests_session.return_value.post.return_value = r
         mock_client_log_request.return_value = None
         mock_fetch_request_token.return_value = {'key': 'key',
@@ -106,7 +104,7 @@ class TestClient(unittest.TestCase):
         # mock the OAuth1 and session post response
         mock_oauth1.return_value = 'oauth'
         r = Mock()
-        r.content = 'oauth_token=key'
+        r.text = 'oauth_token=key'
         self.mock_requests_session.return_value.post.return_value = r
         self.client._token = {'key': 'key',
                               'secret': 'secret',
@@ -128,13 +126,12 @@ class TestClient(unittest.TestCase):
                          'oauth_callback_confirmed=true')
 
     def test_logon(self):
-        with nested(
-            patch('ox3apiclient.Client.fetch_request_token'),
-            patch('ox3apiclient.Client.authorize_token'),
-            patch('ox3apiclient.Client.fetch_access_token'),
-            patch('ox3apiclient.Client.validate_session'),
-        ) as (mock_fetch_request_token, mock_authorize_token,
-              mock_fetch_access_token, mock_validate_session):
+        with patch('ox3apiclient.Client.fetch_request_token') as\
+        mock_fetch_request_token,\
+        patch('ox3apiclient.Client.authorize_token') as mock_authorize_token,\
+        patch('ox3apiclient.Client.fetch_access_token') as\
+        mock_fetch_access_token,\
+        patch('ox3apiclient.Client.validate_session') as mock_validate_session:
             mock_fetch_request_token.return_value = None
             mock_authorize_token.return_value = None
             mock_fetch_access_token.return_value = None
@@ -156,31 +153,31 @@ class TestClient(unittest.TestCase):
                                    'key3': 'value3'})
 
     def test_options(self):
-        ret_val = self.client.options('https://example.com')
+        ret_val = self.client.options(self.url)
         self.assertEqual(ret_val, {'key1': 'value1',
                                    'key2': 'value2',
                                    'key3': 'value3'})
 
     def test_put(self):
-        ret_val = self.client.put('https://example.com', data={'k': 'v'})
+        ret_val = self.client.put(self.url, data={'k': 'v'})
         self.assertEqual(ret_val, {'key1': 'value1',
                                    'key2': 'value2',
                                    'key3': 'value3'})
 
     def test_post(self):
-        ret_val = self.client.post('https://example.com', data={'k': 'v'})
+        ret_val = self.client.post(self.url, data={'k': 'v'})
         self.assertEqual(ret_val, {'key1': 'value1',
                                    'key2': 'value2',
                                    'key3': 'value3'})
 
-    @patch('ox3apiclient.requests.delete')
+    @patch('ox3apiclient.requests.Session.delete')
     @patch('ox3apiclient.Client.log_request')
-    def test_delete(self, mock_client_log_request, mock_requests_delete):
+    def test_delete(self, mock_client_log_request, mock_requests_session_delete):
         mock_client_log_request.return_value = None
         r = Mock()
         r.status_code = 204
-        mock_requests_delete.return_value = r
-        ret_val = self.client.delete('https://example.com')
+        mock_requests_session_delete.return_value = r
+        ret_val = self.client.delete(self.url)
         self.assertEqual(ret_val, [])
 
         r.status_code = 200
@@ -190,7 +187,7 @@ class TestClient(unittest.TestCase):
         # self.assertEqual(ret_val, {'key': 'value'})
 
         r.json.return_value = {'key': 'value'}
-        ret_val = self.client.delete('https://example.com')
+        ret_val = self.client.delete(self.url)
         self.assertEqual(ret_val, {'key': 'value'})
 
     def test_upload_creative(self):


### PR DESCRIPTION
I changed the library to use `response.text` rather than `response.content` as this will allow the text to be automatically decoded in both python 2.6+ and python 3. Also, the six library is used to bridge the gap between python 2 and 3.
