### PR TITLE
Allow passing params while making GET requests to openx API

### DIFF
--- a/ox3apiclient/__init__.py
+++ b/ox3apiclient/__init__.py
@@ -313,11 +313,11 @@ class Client(object):
         except ValueError:
             return response.content
 
-    def get(self, url):
+    def get(self, url, params=None):
         """Issue a GET request to the given URL or API shorthand
 
         """
-        response = self._session.get(self._resolve_url(url), timeout=self.timeout)
+        response = self._session.get(self._resolve_url(url), params=params, timeout=self.timeout)
         self.log_request(response)
         response.raise_for_status()
         return self._response_value(response)


### PR DESCRIPTION
I've found it somewhat inconvenient that one has to prepare the whole `url` manually in order to make a `Client.get` request. This means you should use `urllib.urlencode` or something like that to construct the query string. 

This little fix makes it possible to streamline `params` argument to `requests` library which is capable of handling them correctly without any hustle:
```python
client.get('/report/run', {'start_date': start_date, 'end_date': end_date, 'report': 'inv_rev'})
```