### PR TITLE
Add ‘six’ to install_requires in setup.py

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,5 @@
+mock
+nose
+requests
+requests-oauthlib
+six

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='ox3apiclient',
       description='Client to connect to OpenX Enterprise API.',
       long_description='Client to connect to OpenX Enterprise API.',
       packages=find_packages(),
-      install_requires=['requests_oauthlib'],
+      install_requires=['six','requests_oauthlib'],
       classifiers=[
         'Environment :: Console',
         'Environment :: Web Environment',


### PR DESCRIPTION
Tests pass:

```
(foobar3) mbp-op-226:~/ox/github/OX3-Python-API-Client(fixes)$ nosetests -sxv tests
test_authorize_token (test_client.TestClient) ... ok
test_delete (test_client.TestClient) ... ok
test_fetch_access_token (test_client.TestClient) ... ok
test_fetch_request_token (test_client.TestClient) ... ok
test_get (test_client.TestClient) ... ok
test_logoff (test_client.TestClient) ... ok
test_logon (test_client.TestClient) ... ok
test_options (test_client.TestClient) ... ok
test_post (test_client.TestClient) ... ok
test_put (test_client.TestClient) ... ok
test_upload_creative (test_client.TestClient) ... ok
test_validate_session (test_client.TestClient) ... ok
test_loads_alternate_env (test_clientfromfile.ClientFromFileTestCase) ... ok
test_loads_default_env (test_clientfromfile.ClientFromFileTestCase) ... ok
test_loads_optional_options (test_clientfromfile.ClientFromFileTestCase) ... ok
test_missing_required_option_raises_error (test_clientfromfile.ClientFromFileTestCase) ... ok
test_returns_client (test_clientfromfile.ClientFromFileTestCase) ... ok

----------------------------------------------------------------------
Ran 17 tests in 0.535s

OK
```