### PR TITLE
Added Retry policy to API Client

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,7 @@
-
+0.6.2 / 2021-03-10
+=================
+  * Added Retry policy to API Client
+  
 0.6.1 / 2019-07-23
 =================
   * Add ODS endpoint to supported endpoint list

--- a/ox3apiclient/__init__.py
+++ b/ox3apiclient/__init__.py
@@ -112,7 +112,6 @@ class Client(object):
         self._session.mount('http://', adapter)
         self._session.mount('https://', adapter)
 
-
         # set supplied headers and proxies
         if headers:
             self._session.headers.update(headers)


### PR DESCRIPTION
Fix for SSO connection timeouts, similar to fix for oxbot-api: https://github.com/openx/oxbot-api/pull/45/

example error from oxbot tests:
```
ConnectionError: HTTPSConnectionPool(host='test-sso.openx.org', port=443): Max retries exceeded with url: /api/index/initiate (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f0fe53ddac8>: Failed to establish a new connection: [Errno 110] Connection timed out',))	
18:30:11.110	DEBUG	Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/oxbot/pdm/pdm.py", line 326, in pdm_start_suite
    self._set_suite_variables(suite, suite.pub_instance, suite.pub_user, suite.pub_definition, pub_host)
  File "/usr/local/lib/python3.6/site-packages/oxbot/pdm/pdm.py", line 176, in _set_suite_variables
    self.login(user=user, instance=instance, instance_data=instance_data)
  File "/usr/local/lib/python3.6/site-packages/oxbot/pdm/pdm.py", line 139, in login
    self.api_request.api_login(self.SUITES[suite_name].environment, instance, user, password)
  File "/usr/local/lib/python3.6/site-packages/oxbot/api/decorators/loggers.py", line 42, in function_wrapper
    output = fun(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/oxbot/api/APIRequests.py", line 120, in api_login
    self.api.token = self._login_and_get_access_token(instance_id, email, password, custom_token)
  File "/usr/local/lib/python3.6/site-packages/oxbot/api/APIRequests.py", line 722, in _login_and_get_access_token
    return self._ox3apiclient_login(email, password)
  File "/usr/local/lib/python3.6/site-packages/oxbot/api/APIRequests.py", line 748, in _ox3apiclient_login
    self.api.ox3api.logon(email=email, password=password)
  File "/usr/local/lib/python3.6/site-packages/ox3apiclient/__init__.py", line 260, in logon
    self.fetch_request_token()
  File "/usr/local/lib/python3.6/site-packages/ox3apiclient/__init__.py", line 165, in fetch_request_token
    response = self._session.post(url=self.request_token_url, auth=oauth, timeout=self.timeout)
  File "/usr/local/lib/python3.6/site-packages/requests/sessions.py", line 590, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/requests/sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.6/site-packages/requests/sessions.py", line 655, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/requests/adapters.py", line 516, in send
    raise ConnectionError(e, request=request)
```